### PR TITLE
Handle fully qualified channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-- 2.7
 - 3.4
 - 3.5
 - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 
 python:
+- 2.7
 - 3.4
 - 3.5
+- 3.6
 
 install:
 - git clone https://github.com/ericdill/ci ~/scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ python:
 - 3.6
 
 install:
-- git clone https://github.com/ericdill/ci ~/scripts
-- . ~/scripts/install-miniconda.sh
-- conda install python=$TRAVIS_PYTHON_VERSION pip conda-build
-- conda update --all
 - pip install -r test-requirements.txt
 - pip install codecov
 - pip install -e .

--- a/README.md
+++ b/README.md
@@ -95,28 +95,35 @@ whitelist:
 ## CLI
 ```
 $ conda-mirror -h
-['/home/edill/miniconda/bin/conda-mirror', '-h']
-usage: conda-mirror [-h] --upstream-channel UPSTREAM_CHANNEL
-                    --target-directory TARGET_DIRECTORY
-                    [--temp-directory TEMP_DIRECTORY] --platform PLATFORM [-v]
-                    [--config CONFIG] [--pdb]
+usage: conda-mirror [-h] [--upstream-channel UPSTREAM_CHANNEL]
+                    [--target-directory TARGET_DIRECTORY]
+                    [--temp-directory TEMP_DIRECTORY] [--platform PLATFORM]
+                    [-v] [--config CONFIG] [--pdb] [--version]
 
 CLI interface for conda-mirror.py
 
 optional arguments:
   -h, --help            show this help message and exit
   --upstream-channel UPSTREAM_CHANNEL
-                        The anaconda channel to mirror
+                        The target channel to mirror. Can be a channel on
+                        anaconda.org like "conda-forge" or a full qualified
+                        channel like "https://repo.continuum.io/pkgs/free/"
   --target-directory TARGET_DIRECTORY
                         The place where packages should be mirrored to
   --temp-directory TEMP_DIRECTORY
-                        Temporary download location for the packages
+                        Temporary download location for the packages. Defaults
+                        to a randomly selected temporary directory. Note that
+                        you might need to specify a different location if your
+                        default temp directory has less available space than
+                        your mirroring target
   --platform PLATFORM   The OS platform(s) to mirror. one of: {'linux-64',
                         'linux-32','osx-64', 'win-32', 'win-64'}
-  -v, --verbose         This basically turns on tqdm progress bars for
-                        downloads
+  -v, --verbose         logging defaults to error/exception only. Takes up to
+                        three '-v' flags. '-v': warning. '-vv': info. '-vvv':
+                        debug.
   --config CONFIG       Path to the yaml config file
   --pdb                 Enable PDB debugging on exception
+  --version             Print version and quit
 ```
 
 ## Testing
@@ -136,21 +143,21 @@ Requirement already satisfied: py>=1.4.29 in /home/edill/miniconda/lib/python3.5
 ### Run the tests, invoking with the `coverage` tool.
 
 ```
-$ coverage run run_tests.py -x
-sys.argv=['run_tests.py', '-x']
-================================================================================== test session starts ===================================================================================
-platform linux -- Python 3.5.2, pytest-3.0.4, py-1.4.31, pluggy-0.4.0 -- /home/edill/miniconda/bin/python
+$ coverage run run_tests.py
+sys.argv=['run_tests.py']
+========================================= test session starts ==========================================
+platform linux -- Python 3.5.3, pytest-3.0.6, py-1.4.31, pluggy-0.4.0 -- /home/edill/miniconda/bin/python
 cachedir: .cache
-rootdir: /home/edill/dev/maxpoint/conda-mirror, inifile:
-plugins: xonsh-0.4.7, ordering-0.4
+rootdir: /home/edill/dev/maxpoint/github/conda-mirror, inifile:
+plugins: xonsh-0.5.2, ordering-0.4
 collected 4 items
 
 test/test_conda_mirror.py::test_match PASSED
-test/test_conda_mirror.py::test_cli[anaconda-linux-64] PASSED
+test/test_conda_mirror.py::test_cli[https://repo.continuum.io/pkgs/free-linux-64] PASSED
 test/test_conda_mirror.py::test_cli[conda-forge-linux-64] PASSED
 test/test_conda_mirror.py::test_handling_bad_package PASSED
 
-=============================================================================== 4 passed in 15.66 seconds ================================================================================
+======================================= 4 passed in 4.41 seconds =======================================
 ```
 
 ### Show the coverage statistics
@@ -160,9 +167,9 @@ $ coverage report -m
 Name                           Stmts   Miss  Cover   Missing
 ------------------------------------------------------------
 conda_mirror/__init__.py           3      0   100%
-conda_mirror/conda_mirror.py     210     16    92%   176, 219-221, 226-232, 244, 369, 413-414, 492
+conda_mirror/conda_mirror.py     236     20    92%   203-205, 209-210, 214, 240, 249-254, 262-264, 303, 366, 497, 542-543, 629
 ------------------------------------------------------------
-TOTAL                            213     16    92%
+TOTAL                            239     20    92%
 ```
 
 ## Other

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -373,7 +373,7 @@ def _download(url, target_directory, package_metadata=None, validate=True,
 
 
 def _list_conda_packages(local_dir):
-    """List the conda packages (*.tar.bz2 files) in `local_dir
+    """List the conda packages (*.tar.bz2 files) in `local_dir`
 
     Parameters
     ----------
@@ -394,7 +394,8 @@ def _validate_packages(package_repodata, package_directory):
 
     NOTE: This is slow.
     NOTE2: This will remove any packages that are in `package_directory` that
-           are not in `repodata`
+           are not in `repodata` and also any packages that fail the package
+           validation
 
     Parameters
     ----------

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -153,6 +153,12 @@ def _make_arg_parser():
         help="Enable PDB debugging on exception",
         default=False,
     )
+    ap.add_argument(
+        '--version',
+        action="store_true",
+        help="Print version and quit",
+        default=False,
+    )
     return ap
 
 

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -262,6 +262,10 @@ def _get_output(cmd):
     except subprocess.CalledProcessError as cpe:
         logger.exception(cpe.output.decode())
         return ""
+    except Exception:
+        msg = "Error in subprocess.check_output. cmd: '%s'"
+        logger.exception(msg, ' '.join(cmd))
+        return ""
 
 
 def _validate(filename, md5=None, sha256=None, size=None):

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -118,12 +118,10 @@ def _make_arg_parser():
         help=('The target channel to mirror. Can be a channel on anaconda.org '
               'like "conda-forge" or a full qualified channel like '
               '"https://repo.continuum.io/pkgs/free/"'),
-        required=True
     )
     ap.add_argument(
         '--target-directory',
         help='The place where packages should be mirrored to',
-        required=True
     )
     ap.add_argument(
         '--temp-directory',
@@ -131,14 +129,12 @@ def _make_arg_parser():
               'randomly selected temporary directory. Note that you might need '
               'to specify a different location if your default temp directory '
               'has less available space than your mirroring target'),
-        required=False,
         default=tempfile.gettempdir()
     )
     ap.add_argument(
         '--platform',
         help=("The OS platform(s) to mirror. one of: {'linux-64', 'linux-32',"
               "'osx-64', 'win-32', 'win-64'}"),
-        required=True
     )
     ap.add_argument(
         '-v', '--verbose',
@@ -178,9 +174,18 @@ def cli():
 
     logger.addHandler(stream_handler)
 
-    logger.info(sys.argv)
+    logger.debug(sys.argv)
     parser = _make_arg_parser()
     args = parser.parse_args()
+    if args.version:
+        from . import __version__
+        print(__version__)
+        return
+
+    for required in ('target_directory', 'platform', 'upstream_channel'):
+        if not getattr(args, required):
+            logger.error("Missing required argument: %s", required)
+            return
 
     if args.verbose:
         logger.setLevel(logging.DEBUG)

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -16,10 +16,8 @@ def repodata():
     repodata = {}
     repodata['conda-forge'] = conda_mirror.get_repodata('conda-forge',
                                                         'linux-64')
-    original_download_url = conda_mirror.DOWNLOAD_URL
-    conda_mirror.update_download_url(anaconda_channel)
-    repodata[anaconda_channel] = conda_mirror.get_repodata('free', 'linux-64')
-    conda_mirror.DOWNLOAD_URL = original_download_url
+    repodata[anaconda_channel] = conda_mirror.get_repodata(anaconda_channel,
+                                                           'linux-64')
     return repodata
 
 

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -28,7 +28,7 @@ def test_match(repodata):
 
 @pytest.mark.parametrize(
     'channel,platform',
-    itertools.product(['anaconda', 'conda-forge'], ['linux-64']))
+    itertools.product(['https://repo.continuum.io/pkgs/free', 'conda-forge'], ['linux-64']))
 def test_cli(tmpdir, channel, platform, repodata):
     info, packages = repodata[channel]
     smallest_package = sorted(packages, key=lambda x: packages[x]['size'])[0]


### PR DESCRIPTION
Can you give this branch a try @dmarkwat? I haven't finished fixing up the test suite to allow fully qualified channels like this, but I'm pretty sure it's functional.  This should enable you to pass fully qualified channels like

```bash
conda-mirror --upstream-channel https://repo.continuum.io/pkgs/free --target-directory /tmp/free --platform linux-64
```

or the pro one, in your case.

(I think) you can install this with `pip install git+https://github.com/ericdill/conda-mirror@issue25/conda-mirror`.  Will make sure after I open the PR and update this if need be