### PR TITLE
Validate the local package cache before mirroring new packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,42 @@
 # Change Log
 
-## [Unreleased](https://github.com/maxpoint/conda-mirror/tree/HEAD)
+## [0.6.2](https://github.com/maxpoint/conda-mirror/tree/0.6.2) (2017-02-07)
 
-[Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.6.0...HEAD)
+[Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.6.1...HEAD)
+
+**Closed issues:**
+
+- Mirror pro repo [\#24](https://github.com/maxpoint/conda-mirror/issues/24)
+
+**Merged pull requests:**
+
+- Handle fully qualified channels [\#25](https://github.com/maxpoint/conda-mirror/pull/25) ([ericdill](https://github.com/ericdill))
+
+## [0.6.1](https://github.com/maxpoint/conda-mirror/tree/0.6.1) (2017-01-18)
+[Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.6.0...0.6.1)
 
 **Closed issues:**
 
 - Validate that there is enough space to actually perform the mirror [\#19](https://github.com/maxpoint/conda-mirror/issues/19)
+
+**Merged pull requests:**
+
+- MNT: Fix the download url for anaconda/defaults [\#23](https://github.com/maxpoint/conda-mirror/pull/23) ([ericdill](https://github.com/ericdill))
+- DOC/MNT: Remove dead code. Update readme. Update changelog [\#22](https://github.com/maxpoint/conda-mirror/pull/22) ([ericdill](https://github.com/ericdill))
 
 ## [0.6.0](https://github.com/maxpoint/conda-mirror/tree/0.6.0) (2017-01-10)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.5.1...0.6.0)
 
 **Merged pull requests:**
 
-- Implement optional cli flag for temp download directory [\#21](https://github.com/maxpoint/conda-mirror/pull/21) ([jneines](https://github.com/jneines))
+- Update conda\_mirror.py [\#21](https://github.com/maxpoint/conda-mirror/pull/21) ([jneines](https://github.com/jneines))
 
 ## [0.5.1](https://github.com/maxpoint/conda-mirror/tree/0.5.1) (2017-01-03)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.5.0...0.5.1)
 
 **Merged pull requests:**
 
-- Download repodata to temp dir first, then move it [\#20](https://github.com/maxpoint/conda-mirror/pull/20) ([ericdill](https://github.com/ericdill))
+- download repodata to temp dir first, then move it [\#20](https://github.com/maxpoint/conda-mirror/pull/20) ([ericdill](https://github.com/ericdill))
 
 ## [0.5.0](https://github.com/maxpoint/conda-mirror/tree/0.5.0) (2016-12-19)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.4.6...0.5.0)
@@ -37,22 +53,14 @@
 ## [0.4.6](https://github.com/maxpoint/conda-mirror/tree/0.4.6) (2016-12-15)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.4.5...0.4.6)
 
-- Prune repodata.json of packages we do not have locally [957f662](https://github.com/maxpoint/conda-mirror/commit/957f66260a8e91c7217656ab721db52b9bc27aa1)
-
 ## [0.4.5](https://github.com/maxpoint/conda-mirror/tree/0.4.5) (2016-12-15)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.4.4...0.4.5)
-
-- (Performance) Short-circuit the validation if one of the checks fail [68ebd00](https://github.com/maxpoint/conda-mirror/commit/68ebd00e8747a504d00bfd4304e480afcbf7b24b)
 
 ## [0.4.4](https://github.com/maxpoint/conda-mirror/tree/0.4.4) (2016-12-15)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.4.3...0.4.4)
 
-- (Performance) Don't validate the entire repo every time (c811397)[https://github.com/maxpoint/conda-mirror/commit/c8113976b80af7e789814d8b9095ece8e5481879]
-
 ## [0.4.3](https://github.com/maxpoint/conda-mirror/tree/0.4.3) (2016-12-15)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.4.2...0.4.3)
-
-- Show output of subprocess calls on failure [e8ba6d4](https://github.com/maxpoint/conda-mirror/commit/e8ba6d4e01febaae5b08127ef71d36a3533b368b)
 
 ## [0.4.2](https://github.com/maxpoint/conda-mirror/tree/0.4.2) (2016-12-13)
 [Full Changelog](https://github.com/maxpoint/conda-mirror/compare/0.4.1...0.4.2)

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -587,8 +587,9 @@ def main(upstream_channel, target_directory, temp_directory, platform,
         # remake the packages dictionary with only the packages we have
         # locally
         repodata['packages'] = {
-            name: info for name, info in repodata['packages'].items()
+            pkg_name: packages[pkg_name] for pkg_name in packages_we_have
             if name in packages_we_have}
+
         _write_repodata(download_dir, repodata)
 
         # move new conda packages

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -426,14 +426,16 @@ def _validate_packages(repodata_packages_metadata, package_directory,
                            md5=package_metadata.get('md5'),
                            sha256=package_metadata.get('sha256'),
                            size=package_metadata.get('size'))
-        if result and update_repodata:
-            import pdb
-            pdb.set_trace()
-            repodata_path = os.path.join(package_directory, 'repodata.json')
-            with open(repodata_path, 'r') as f:
-                repodata = json.load(f)
-                del repodata['packages'][package]
-                _write_repodata(package_directory, repodata)
+        if result:
+            _remove_package(
+                os.path.join(package_directory, package),
+                reason="{2} check failed because {0}!={1}".format(*result))
+            if update_repodata:
+                repodata_path = os.path.join(package_directory, 'repodata.json')
+                with open(repodata_path, 'r') as f:
+                    repodata = json.load(f)
+                    del repodata['packages'][package]
+                    _write_repodata(package_directory, repodata)
 
 
 def main(upstream_channel, target_directory, temp_directory, platform,

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -298,16 +298,9 @@ def _validate(filename, md5=None, sha256=None, size=None):
         if target is not None:
             validation_output = validate_function()
             try:
-                assert target == validation_output
+                assert target == validation_output, description
             except AssertionError:
-                logger.info("Package validation failed for %s: %s != %s",
-                            description, target, validation_output,
-                            exc_info=True)
-                remove_message = "Failed %s test" % description
-                _remove_package(filename, reason=remove_message)
-                return remove_message
-            else:
-                logger.debug('%s check passed', description)
+                return target, validation_output, description
 
 
 def get_repodata(channel, platform):
@@ -414,7 +407,7 @@ def _validate_packages(repodata_packages_metadata, package_directory,
     """
     # validate local conda packages
     local_packages = _list_conda_packages(package_directory)
-    for idx, package in enumerate(local_packages):
+    for idx, package in enumerate(sorted(local_packages)):
         # ensure the packages in this directory are in the upstream
         # repodata.json
         try:
@@ -434,6 +427,8 @@ def _validate_packages(repodata_packages_metadata, package_directory,
                            sha256=package_metadata.get('sha256'),
                            size=package_metadata.get('size'))
         if result and update_repodata:
+            import pdb
+            pdb.set_trace()
             repodata_path = os.path.join(package_directory, 'repodata.json')
             with open(repodata_path, 'r') as f:
                 repodata = json.load(f)

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -548,6 +548,12 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     logger.debug('possible_packages_to_mirror')
     logger.debug(pformat(sorted(possible_packages_to_mirror)))
 
+    # 3. Validate all files locally
+    ideal_repodata = {
+        pkg_name: pkg_info for pkg_name, pkg_info in packages.items()
+        if pkg_name in possible_packages_to_mirror}
+    _validate_packages(ideal_repodata, local_directory, update_repodata=True)
+
     # 5. figure out final list of packages to mirror
     # do the set difference of what is local and what is in the final
     # mirror list
@@ -582,7 +588,7 @@ def main(upstream_channel, target_directory, temp_directory, platform,
         info, packages = get_repodata(channel, platform)
         repodata = {'info': info, 'packages': packages}
         # compute the packages that we have locally
-        packages_we_have = set(local_packages +
+        packages_we_have = set(_list_conda_packages(local_directory) +
                                _list_conda_packages(download_dir))
         # remake the packages dictionary with only the packages we have
         # locally

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -160,6 +160,13 @@ def _make_arg_parser():
         help="Print version and quit",
         default=False,
     )
+    ap.add_argument(
+        '--validate-local-channel',
+        action="store_false",
+        help="Validate the conda packages in the local mirror. Note that will "
+             "take a few seconds per package",
+        default=True
+    )
     return ap
 
 
@@ -224,7 +231,7 @@ def cli():
     whitelist = config_dict.get('whitelist')
 
     main(args.upstream_channel, args.target_directory, args.temp_directory,
-         args.platform, blacklist, whitelist)
+         args.platform, blacklist, whitelist, args.validate_local_channel)
 
 
 def _remove_package(pkg_path, reason=None):
@@ -241,19 +248,6 @@ def _remove_package(pkg_path, reason=None):
     msg = "Removing: %s. Reason: %s"
     logger.warning(msg, pkg_path, reason)
     os.remove(pkg_path)
-
-
-def _assert_or_remove(left, right, assertion_test, filename):
-    try:
-        assert left == right
-    except AssertionError:
-        logger.info("Package validation failed for %s: %s != %s",
-                    assertion_test, left, right,
-                    exc_info=True)
-        _remove_package(filename, reason="Failed %s test" % assertion_test)
-        return True
-    else:
-        logger.debug('%s check passed', assertion_test)
 
 
 def _get_output(cmd):
@@ -302,9 +296,18 @@ def _validate(filename, md5=None, sha256=None, size=None):
     ]
     for target, validate_function, description in checks:
         if target is not None:
-            if _assert_or_remove(target, validate_function(), description,
-                                 filename):
-                return
+            validation_output = validate_function()
+            try:
+                assert target == validation_output
+            except AssertionError:
+                logger.info("Package validation failed for %s: %s != %s",
+                            description, target, validation_output,
+                            exc_info=True)
+                remove_message = "Failed %s test" % description
+                _remove_package(filename, reason=remove_message)
+                return remove_message
+            else:
+                logger.debug('%s check passed', description)
 
 
 def get_repodata(channel, platform):
@@ -389,7 +392,8 @@ def _list_conda_packages(local_dir):
     return fnmatch.filter(contents, "*.tar.bz2")
 
 
-def _validate_packages(package_repodata, package_directory):
+def _validate_packages(repodata_packages_metadata, package_directory,
+                       update_repodata=True):
     """Validate local conda packages.
 
     NOTE: This is slow.
@@ -399,10 +403,14 @@ def _validate_packages(package_repodata, package_directory):
 
     Parameters
     ----------
-    package_repodata : dict
-        The contents of repodata.json
+    repodata_packages_metadata : dict
+        The value of the 'repodata' key in repodata.json
     package_directory : str
         Path to the local repo that contains conda packages
+    update_repodata : bool, optional
+        True: Atomically update repodata.json every time a package is removed
+        that fails its validation checks
+        Defaults to True.
     """
     # validate local conda packages
     local_packages = _list_conda_packages(package_directory)
@@ -410,25 +418,31 @@ def _validate_packages(package_repodata, package_directory):
         # ensure the packages in this directory are in the upstream
         # repodata.json
         try:
-            package_metadata = package_repodata[package]
+            package_metadata = repodata_packages_metadata[package]
         except KeyError:
             logger.warning("%s is not in the upstream index. Removing...",
                            package)
             _remove_package(os.path.join(package_directory, package),
                             reason="Package is not in the repodata index")
-        else:
-            # validate the integrity of the package, the size of the package and
-            # its hashes
-            logger.info('Validating %s. %s of %s', package, idx,
-                        len(local_packages))
-            _validate(os.path.join(package_directory, package),
-                      md5=package_metadata.get('md5'),
-                      sha256=package_metadata.get('sha256'),
-                      size=package_metadata.get('size'))
+            continue
+        # validate the integrity of the package, the size of the package and
+        # its hashes
+        logger.info('Validating %s. %s of %s', package, idx,
+                    len(local_packages))
+        result = _validate(os.path.join(package_directory, package),
+                           md5=package_metadata.get('md5'),
+                           sha256=package_metadata.get('sha256'),
+                           size=package_metadata.get('size'))
+        if result and update_repodata:
+            repodata_path = os.path.join(package_directory, 'repodata.json')
+            with open(repodata_path, 'r') as f:
+                repodata = json.load(f)
+                del repodata['packages'][package]
+                _write_repodata(package_directory, repodata)
 
 
 def main(upstream_channel, target_directory, temp_directory, platform,
-         blacklist=None, whitelist=None):
+         blacklist=None, whitelist=None, validate_local_channel=False):
     """
 
     Parameters
@@ -449,14 +463,18 @@ def main(upstream_channel, target_directory, temp_directory, platform,
         The platform that you wish to mirror for. Common options are
         'linux-64', 'osx-64', 'win-64' and 'win-32'. Any platform is valid as
         long as the url resolves.
-    blacklist : iterable of tuples
+    blacklist : iterable of tuples, optional
         The values of blacklist should be (key, glob) where key is one of the
         keys in the repodata['packages'] dicts and glob is a thing to match
         on.  Note that all comparisons will be laundered through lowercasing.
-    whitelist : iterable of tuples
+    whitelist : iterable of tuples, optional
         The values of blacklist should be (key, glob) where key is one of the
         keys in the repodata['packages'] dicts and glob is a thing to match
         on.  Note that all comparisons will be laundered through lowercasing.
+    validate_local_channel : bool, optional
+        True: Validate the contents of the local mirror against all possible
+        info contained in the package metadata in repodata.json. This is
+        pretty darn slow. Takes a few seconds per package.
 
     Notes
     -----
@@ -489,7 +507,7 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     # Steps:
     # 1. figure out blacklisted packages
     # 2. un-blacklist packages that are actually whitelisted
-    # 3. remove blacklisted packages
+    # 3. Maybe validate local channel
     # 4. figure out final list of packages to mirror
     # 5. mirror new packages to temp dir
     # 6. validate new packages
@@ -504,12 +522,7 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     info, packages = get_repodata(upstream_channel, platform)
     local_directory = os.path.join(target_directory, platform)
 
-    # 1. validate local repo
-    # validating all packages is taking many hours.
-    # _validate_packages(repodata=repodata,
-    #                    package_directory=local_directory)
-
-    # 2. figure out blacklisted packages
+    # 1. figure out blacklisted packages
     blacklist_packages = {}
     whitelist_packages = {}
     # match blacklist conditions
@@ -521,7 +534,7 @@ def main(upstream_channel, target_directory, temp_directory, platform,
             blacklist_packages.update(matched_packages)
         logger.debug(pformat(sorted(blacklist_packages)))
 
-    # 3. un-blacklist packages that are actually whitelisted
+    # 2. un-blacklist packages that are actually whitelisted
     # match whitelist on blacklist
     if whitelist:
         logger.debug("whitelist")
@@ -539,14 +552,17 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     logger.debug('possible_packages_to_mirror')
     logger.debug(pformat(sorted(possible_packages_to_mirror)))
 
-    # 4. remove blacklisted packages
-    # get list of current packages in folder
-    local_packages = _list_conda_packages(local_directory)
-    # if any are not in the final mirror list, remove them
-    for package_name in local_packages:
-        if package_name in true_blacklist:
-            _remove_package(os.path.join(local_directory, package_name),
-                            reason="Package is blacklisted")
+    # 3. Validate local channel before mirroring new packages
+    if validate_local_channel:
+        if not os.path.isdir(local_directory):
+            logger.warning("validate_local_channel is set to %s but the local "
+                           "mirror does not appear to exist: %s",
+                           validate_local_channel, local_directory)
+        else:
+            allowed_package_metadata = {k: packages[k] for k in
+                                        possible_packages_to_mirror}
+            _validate_packages(allowed_package_metadata, local_directory)
+
     # 5. figure out final list of packages to mirror
     # do the set difference of what is local and what is in the final
     # mirror list
@@ -571,14 +587,13 @@ def main(upstream_channel, target_directory, temp_directory, platform,
             _download(url, download_dir, packages)
 
         # validate all packages in the download directory
-        _validate_packages(packages, download_dir)
+        _validate_packages(packages, download_dir, update_repodata=False)
         logger.debug('contents of %s are %s',
                      download_dir,
                      pformat(os.listdir(download_dir)))
 
-        # 8. Use already downloaded repodata.json contents but prune it of
-        # packages we don't want
-        repodata_path = os.path.join(download_dir, 'repodata.json')
+        # 8. Use the repodata we have in ram, but prune it of packages
+        # we don't want
 
         repodata = {'info': info, 'packages': packages}
         # compute the packages that we have locally
@@ -612,6 +627,9 @@ def main(upstream_channel, target_directory, temp_directory, platform,
 
 
 def _write_repodata(package_dir, repodata_dict):
+    td = tempfile.mkdtemp(prefix='conda-mirror')
+    logger.debug("Writing repodata.json and repodata.json.bz2 to temp dir: "
+                 "%s", td)
     data = json.dumps(repodata_dict, indent=2, sort_keys=True)
     # strip trailing whitespace
     data = '\n'.join(line.rstrip() for line in data.splitlines())
@@ -619,15 +637,19 @@ def _write_repodata(package_dir, repodata_dict):
     if not data.endswith('\n'):
         data += '\n'
 
-    with open(os.path.join(package_dir,
-                           'repodata.json'), 'w') as fo:
+    with open(os.path.join(td, 'repodata.json'), 'w') as fo:
         fo.write(data)
 
     # compress repodata.json into the bz2 format. some conda commands still
     # need it
-    bz2_path = os.path.join(package_dir, 'repodata.json.bz2')
+    bz2_path = os.path.join(td, 'repodata.json.bz2')
     with open(bz2_path, 'wb') as fo:
         fo.write(bz2.compress(data.encode('utf-8')))
+
+    for f in ('repodata.json', 'repodata.json.bz2'):
+        logger.debug('Moving %s from tempdir to %s', f, package_dir)
+        shutil.move(os.path.join(td, f),
+                    os.path.join(package_dir, f))
 
 
 if __name__ == "__main__":

--- a/scripts/inspect-channel.py
+++ b/scripts/inspect-channel.py
@@ -38,6 +38,12 @@ def cli():
         action='store',
         help="The number of parallel processes to spin up"
     )
+    ap.add_argument(
+        '--cron',
+        action="store_true",
+        help="Disable print calls that don't do so well in logs",
+        default=False
+    )
     args = ap.parse_args()
 
     with open(join(args.pkgs_dir, 'repodata.json'), 'r') as f:
@@ -48,30 +54,38 @@ def cli():
                 for idx, pkg in enumerate(conda_packages))
     start = time.time()
     need_attention = []
+    print_every = len(conda_packages) / 100
+    if print_every < 100:
+        print_every = 100
     with Pool(int(args.num_workers)) as p:
         for i, ret in enumerate(p.imap_unordered(validate, pkg_iter)):
             elapsed = int(time.time()) - int(start) or 1
             pkgs_per_sec = int(i / elapsed) or 1
             eta = int((len(conda_packages) - i) / pkgs_per_sec)
-            msg = ('\r{0}/{1}   {2}s elapsed   {3} processed sec   {4}s remaining'.format(
+            msg = ('{0}/{1}   {2}s elapsed   {3} processed/sec   {4}s remaining'.format(
                 i, len(conda_packages), elapsed, pkgs_per_sec, eta))
-            sys.stderr.write(msg)
+            if not args.cron:
+                sys.stderr.write('\r%s' % msg)
+            else:
+                if i % print_every  == 0:
+                    print('%s\n'% msg)
             if ret is not None:
                 need_attention.append(ret)
-    print('%s packages need attention' % len(need_attention))
+    print('\n%s packages need attention' % len(need_attention))
     for package_path, problem_type, info in need_attention:
         if problem_type == METADATA:
             print("Removing %s because it is not in the local "
-                  "repodata.json" % package_path)
+                  "repodata.json" % (package_path), file=sys.stderr)
             os.remove(package_path)
         elif problem_type == PACKAGE_VALIDATION:
             print("Removing %s because it failed package validation with this "
-                  "reason: %s" % (package_path, info))
+                  "reason: %s" % (package_path, info), file=sys.stderr)
             os.remove(package_path)
             del repodata['packages'][os.path.basename(package_path)]
             # Update the repodata immediately
             cm._write_repodata(os.path.dirname(package_path), repodata)
 
+    print("All packages that require attention")
     pprint(need_attention)
 
 

--- a/scripts/inspect-channel.py
+++ b/scripts/inspect-channel.py
@@ -1,0 +1,80 @@
+from conda_mirror import conda_mirror as cm
+from pprint import pprint
+from argparse import ArgumentParser
+from os.path import join
+import json
+import os
+from multiprocessing import Pool
+import sys
+import time
+
+cm._init_logger(3)
+
+METADATA="No metadata found"
+PACKAGE_VALIDATION="Validation failed"
+
+def validate(pkg_tuple):
+    package_path, package_metadata, idx, total = pkg_tuple
+#    print('%s of %s. validating %s' % (idx, total, package_path))
+    if package_metadata is None:
+        return package_path, METADATA, ""
+    ret = cm._validate(package_path,
+                       md5=package_metadata.get('md5'),
+                       sha256=package_metadata.get('sha256'),
+                       size=package_metadata.get('size'))
+    if ret is not None:
+        return package_path, PACKAGE_VALIDATION, ret
+
+
+def cli():
+    ap = ArgumentParser()
+    ap.add_argument(
+        'pkgs_dir',
+        action='store',
+        help="The path to the directory that you are interested in"
+    )
+    ap.add_argument(
+        'num_workers',
+        action='store',
+        help="The number of parallel processes to spin up"
+    )
+    args = ap.parse_args()
+
+    with open(join(args.pkgs_dir, 'repodata.json'), 'r') as f:
+        repodata = json.load(f)
+
+    conda_packages = cm._list_conda_packages(args.pkgs_dir)
+    pkg_iter = ((join(args.pkgs_dir, pkg), repodata['packages'].get(pkg), idx, len(conda_packages))
+                for idx, pkg in enumerate(conda_packages))
+    start = time.time()
+    need_attention = []
+    with Pool(int(args.num_workers)) as p:
+        for i, ret in enumerate(p.imap_unordered(validate, pkg_iter)):
+            elapsed = int(time.time()) - int(start) or 1
+            pkgs_per_sec = int(i / elapsed) or 1
+            eta = int((len(conda_packages) - i) / pkgs_per_sec)
+            msg = ('\r{0}/{1}   {2}s elapsed   {3} processed sec   {4}s remaining'.format(
+                i, len(conda_packages), elapsed, pkgs_per_sec, eta))
+            sys.stderr.write(msg)
+            if ret is not None:
+                need_attention.append(ret)
+    print('%s packages need attention' % len(need_attention))
+    for package_path, problem_type, info in need_attention:
+        if problem_type == METADATA:
+            print("Removing %s because it is not in the local "
+                  "repodata.json" % package_path)
+            os.remove(package_path)
+        elif problem_type == PACKAGE_VALIDATION:
+            print("Removing %s because it failed package validation with this "
+                  "reason: %s" % (package_path, info))
+            os.remove(package_path)
+            del repodata['packages'][os.path.basename(package_path)]
+            # Update the repodata immediately
+            cm._write_repodata(os.path.dirname(package_path), repodata)
+
+    pprint(need_attention)
+
+
+if __name__ == "__main__":
+    cli()
+

--- a/scripts/inspect-channel.py
+++ b/scripts/inspect-channel.py
@@ -54,9 +54,6 @@ def cli():
                 for idx, pkg in enumerate(conda_packages))
     start = time.time()
     need_attention = []
-    print_every = len(conda_packages) / 100
-    if print_every < 100:
-        print_every = 100
     with Pool(int(args.num_workers)) as p:
         for i, ret in enumerate(p.imap_unordered(validate, pkg_iter)):
             elapsed = int(time.time()) - int(start) or 1
@@ -67,8 +64,8 @@ def cli():
             if not args.cron:
                 sys.stderr.write('\r%s' % msg)
             else:
-                if i % print_every  == 0:
-                    print('%s\n'% msg)
+                if i % 100  == 0:
+                    print('%s'% msg)
             if ret is not None:
                 need_attention.append(ret)
     print('\n%s packages need attention' % len(need_attention))

--- a/scripts/inspect-channel.py
+++ b/scripts/inspect-channel.py
@@ -13,9 +13,9 @@ cm._init_logger(3)
 METADATA="No metadata found"
 PACKAGE_VALIDATION="Validation failed"
 
+
 def validate(pkg_tuple):
-    package_path, package_metadata, idx, total = pkg_tuple
-#    print('%s of %s. validating %s' % (idx, total, package_path))
+    package_path, package_metadata = pkg_tuple
     if package_metadata is None:
         return package_path, METADATA, ""
     ret = cm._validate(package_path,
@@ -50,7 +50,7 @@ def cli():
         repodata = json.load(f)
 
     conda_packages = cm._list_conda_packages(args.pkgs_dir)
-    pkg_iter = ((join(args.pkgs_dir, pkg), repodata['packages'].get(pkg), idx, len(conda_packages))
+    pkg_iter = ((join(args.pkgs_dir, pkg), repodata['packages'].get(pkg))
                 for idx, pkg in enumerate(conda_packages))
     start = time.time()
     need_attention = []


### PR DESCRIPTION
This adds the command line flag `--validate-local-channel` that will run full validation on all local packages. Will take a lot of extra time to do, so enable with caution