### PR TITLE
TST: Fix broken test

### DIFF
--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -78,7 +78,8 @@ whitelist:
                        pkg_name='bad-1-0.tar.bz2')
     # Write a bad package that does exist in the upstream repodata into the mirror path
     # to make sure we can handle that case too
-    upstream_pkg_name = next(iter(repodata.keys()))
+    info, packages = repodata[channel]
+    upstream_pkg_name = next(iter(packages.keys()))
     _write_bad_package(channel_dir=f2.strpath, platform_name=platform,
                        pkg_name=upstream_pkg_name)
     conda_mirror.cli()


### PR DESCRIPTION
Couldn't figure out why this test was intermittently failing. Turns out that the top level keys of the `repodata` dict were `conda-forge` and `https://repo.continuum.io/pkgs/free`. Fun fact: dictionaries in python 3 do not have deterministic ordering, so when I was doing `next(iter(repodata.keys()))` I would be getting `conda-forge` or `https://repo.continuum.io/pkgs/free` in an effectively random fashion. If I was unlucky and got `https://repo.continuum.io/pkgs/free`, then the tests would fail because pytest was trying to write to a very deeply nested folder:

```
 '/tmp/pytest-of-p-edill/pytest-10/test_cli_conda_forge_linux_64_0/conda-forge/linux-64/https://repo.continuum.io/pkgs/free'
```

Also, the colon in the file path probably wasn't helping matters...

In any event, that was *not* the desired behavior. What I really wanted to get were the package names in that repodata dictionary which requires the change in this PR