### PR TITLE
Add concurrent package validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
 
 script:
 - conda-mirror -h
-- coverage run run_tests.py
+- coverage run --concurrency=multiprocessing run_tests.py
+- coverage combine
 - coverage report -m
 
 after_success:


### PR DESCRIPTION
- Use `multiprocessing` from the std lib to concurrently validate
  packages.  Add a cli argument `num-threads` setting the number of
  concurrent processes to be used.

- Add test for three concurrent scenarios:  `num_threads=0` using all
  available cores, `num_threads=1` for serial validation,
  `num_threads=4` explicitly using four processes.

- Adapt Travis script to properly measure test coverage with concurrent
  validation.

This is a cleaned-up version of #45.