### PR TITLE
Capture information on downloaded and removed packages

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -1,20 +1,21 @@
 import argparse
+import bz2
+from collections import defaultdict
+import hashlib
+import json
 import logging
+import multiprocessing
 import os
 import pdb
 import shutil
 import sys
-import json
 import tarfile
 import tempfile
-import traceback
-from glob import fnmatch
+import fnmatch
 from pprint import pformat
-import bz2
+
 import requests
 import yaml
-import hashlib
-import multiprocessing
 
 logger = None
 
@@ -247,10 +248,18 @@ def _remove_package(pkg_path, reason):
     ----------
     pkg_path : str
         Path to a conda package that should be removed
+
+    Returns
+    -------
+    pkg_path : str
+        The full path to the package that is being removed
+    reason : str
+        The reason why the package is being removed
     """
     msg = "Removing: %s. Reason: %s"
     logger.warning(msg, pkg_path, reason)
     os.remove(pkg_path)
+    return pkg_path, msg
 
 
 def _validate(filename, md5=None, size=None):
@@ -269,6 +278,13 @@ def _validate(filename, md5=None, size=None):
     size : int, optional
         if provided, stat the file at `filename` and make sure its size
         matches `size`
+
+    Returns
+    -------
+    pkg_path : str
+        The full path to the package that is being removed
+    reason : str
+        The reason why the package is being removed
     """
     try:
         t = tarfile.open(filename)
@@ -276,20 +292,19 @@ def _validate(filename, md5=None, size=None):
     except tarfile.TarError:
         logger.info("Validation failed because conda package is corrupted.",
                     exc_info=True)
-        _remove_package(filename, reason="Tarfile read failure")
-        return
+        return _remove_package(filename, reason="Tarfile read failure")
     if size:
         if os.stat(filename).st_size != size:
-            _remove_package(filename, reason="Failed size test")
-            return
+            return _remove_package(filename, reason="Failed size test")
     if md5:
         calc = hashlib.md5(open(filename, 'rb').read()).hexdigest()
         if calc != md5:
-            _remove_package(
+            return _remove_package(
                 filename,
                 reason="Failed md5 validation. Expected: %s. Computed: %s"
                 % (calc, md5))
-            return
+
+    return filename, 'This is fine'  # http://imgur.com/c4jt321
 
 
 def get_repodata(channel, platform):
@@ -385,7 +400,8 @@ def _validate_packages(package_repodata, package_directory, num_threads=1):
                          for num, package in enumerate(sorted(local_packages))]
 
     if num_threads is 1 or num_threads is None:
-        map(_validate_or_remove_package, val_func_arg_list)
+        validation_results = map(_validate_or_remove_package,
+                                 val_func_arg_list)
     else:
         if num_threads is 0:
             logger.debug('`num_threads=0` will be replaced by num of all '
@@ -394,9 +410,13 @@ def _validate_packages(package_repodata, package_directory, num_threads=1):
         logger.info('Will use {} threads for package validation.'
                     ''.format(num_threads))
         p = multiprocessing.Pool(num_threads)
-        p.map(_validate_or_remove_package, val_func_arg_list)
+        validation_results = p.map(_validate_or_remove_package,
+                                   val_func_arg_list)
         p.close()
         p.join()
+
+    return [(path, reason) for path, reason in validation_results
+            if reason is not None]
 
 
 def _validate_or_remove_package(args):
@@ -410,6 +430,13 @@ def _validate_or_remove_package(args):
         - `args[2]` is the number of all packages.
         - `args[3]` is `package_repodata`.
         - `args[4]` is `package_directory`.
+
+    Returns
+    -------
+    pkg_path : str
+        The full path to the package that is being removed
+    reason : str
+        The reason why the package is being removed
     """
     # unpack arg tuple tuple
     package = args[0]
@@ -425,16 +452,17 @@ def _validate_or_remove_package(args):
     except KeyError:
         logger.warning("%s is not in the upstream index. Removing...",
                        package)
-        _remove_package(os.path.join(package_directory, package),
-                        reason="Package is not in the repodata index")
-    else:
-        # validate the integrity of the package, the size of the package and
-        # its hashes
-        logger.info('Validating {:4d} of {:4d}: {}.'.format(num, num_packages,
-                                                            package))
-        _validate(os.path.join(package_directory, package),
-                  md5=package_metadata.get('md5'),
-                  size=package_metadata.get('size'))
+        reason = "Package is not in the repodata index"
+        package_path = os.path.join(package_directory, package)
+        return _remove_package(package_path, reason=reason)
+    # validate the integrity of the package, the size of the package and
+    # its hashes
+    logger.info('Validating {:4d} of {:4d}: {}.'.format(num, num_packages,
+                                                        package))
+    package_path = os.path.join(package_directory, package)
+    return _validate(package_path,
+                     md5=package_metadata.get('md5'),
+                     size=package_metadata.get('size'))
 
 
 def main(upstream_channel, target_directory, temp_directory, platform,
@@ -471,6 +499,15 @@ def main(upstream_channel, target_directory, temp_directory, platform,
         Number of threads to be used for concurrent validation.  Defaults to
         `num_threads=1` for non-concurrent mode.  To use all available cores,
         set `num_threads=0`.
+
+    Returns
+    -------
+    dict
+        Summary of what was removed and what was downloaded.
+        keys are:
+        - removed : set of (path, reason) for each package that was removed
+        - downloaded : set of (url, download_path) for each package that
+                       was downloaded
 
     Notes
     -----
@@ -510,6 +547,7 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     # 7. copy new packages to repo directory
     # 8. download repodata.json and repodata.json.bz2
     # 9. copy new repodata.json and repodata.json.bz2 into the repo
+    summary = defaultdict(set)
 
     # Implementation:
     if not os.path.exists(os.path.join(target_directory, platform)):
@@ -558,7 +596,9 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     # construct the desired package repodata
     desired_repodata = {pkgname: packages[pkgname]
                         for pkgname in possible_packages_to_mirror}
-    _validate_packages(desired_repodata, local_directory, num_threads)
+
+    removed = _validate_packages(desired_repodata, local_directory, num_threads)
+    summary['removed'].update(removed)
 
     # 5. figure out final list of packages to mirror
     # do the set difference of what is local and what is in the final
@@ -582,9 +622,12 @@ def main(upstream_channel, target_directory, temp_directory, platform,
                 platform=platform,
                 file_name=package_name)
             _download(url, download_dir)
+            summary['downloaded'].add((url, download_dir))
 
         # validate all packages in the download directory
-        _validate_packages(packages, download_dir, num_threads=num_threads)
+        removed = _validate_packages(packages, download_dir,
+                                     num_threads=num_threads)
+        summary['removed'].update(removed)
         logger.debug('contents of %s are %s',
                      download_dir,
                      pformat(os.listdir(download_dir)))
@@ -622,6 +665,8 @@ def main(upstream_channel, target_directory, temp_directory, platform,
         os.makedirs(noarch_path, exist_ok=True)
         noarch_repodata = {'info': {}, 'packages': {}}
         _write_repodata(noarch_path, noarch_repodata)
+
+    return summary
 
 
 def _write_repodata(package_dir, repodata_dict):

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -516,10 +516,10 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     dict
         Summary of what was removed and what was downloaded.
         keys are:
-        - validation_results : set of (path, reason) for each package that was validated.
-                               packages where reason=None is a sentinel for a successful validation
-        - downloaded : set of (url, download_path) for each package that
-                       was downloaded
+        - validation : set of (path, reason) for each package that was validated.
+                       packages where reason=None is a sentinel for a successful validation
+        - download : set of (url, download_path) for each package that
+                     was downloaded
 
     Notes
     -----

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -132,8 +132,8 @@ def test_main(tmpdir, repodata):
 
     ret = conda_mirror.main(
         upstream_channel=channel,
-        target_directory=target_directory,
-        temp_directory=temp_directory,
+        target_directory=target_directory.strpath,
+        temp_directory=temp_directory.strpath,
         platform='linux-64',
         blacklist=[{'name': '*'}],
         whitelist=[{'name': packages[smallest_package]['name'],

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -35,7 +35,8 @@ def test_match(repodata):
 def test_version():
     old_args = copy.copy(sys.argv)
     sys.argv = ['conda-mirror', '--version']
-    conda_mirror.cli()
+    with pytest.raises(SystemExit):
+        conda_mirror.cli()
     sys.argv = old_args
 
 
@@ -139,6 +140,7 @@ def test_main(tmpdir, repodata):
         whitelist=[{'name': packages[smallest_package]['name'],
                     'version': packages[smallest_package]['version']}])
 
-    assert len(ret['downloaded']) > 0, "We should have downloaded at least one package"
+    assert len(ret['download']) > 0, "We should have downloaded at least one package"
+    assert len(ret['validation']) > 0, "We should have validated at least one package"
 
 


### PR DESCRIPTION
I want to know how many packages were removed and how many were successfully
downloaded without scraping the conda-mirror output. This PR enables that
functionality by having the main function keep track of what is removed and
what is downloaded and returning that information. By doing this, I can import
the main() function from conda-mirror and embed that in a script that parses
this output and does things (like alert me via some pathway) if conda-mirror
fails or removes a large number of packages or any other error condition I can
think of to make an alert off of.